### PR TITLE
Allow 'normal' literals to be used in variable assignment statements

### DIFF
--- a/Rockstar.g4
+++ b/Rockstar.g4
@@ -30,7 +30,7 @@ comparisionOp: KW_IS
              | KW_IS WS KW_AS WS (KW_GREATER_EQUAL|KW_LESS_EQUAL) WS KW_AS
 ;
 
-assignmentStmt: variable (APOSTROPHE_S | WS (KW_IS|KW_WAS_WERE)) WS (poeticNumberLiteral|constant)
+assignmentStmt: variable (APOSTROPHE_S | WS (KW_IS|KW_WAS_WERE)) WS (poeticNumberLiteral|constant|literal)
               | KW_PUT WS expression WS KW_INTO WS variable
               | variable WS KW_SAYS WS poeticStringLiteral
 ;


### PR DESCRIPTION
Thanks for this grammar! I'm using it in https://github.com/holly-cummins/bon-jova-rockstar-implementation, and as I build up test coverage, I'm noticing a few little issues. 

It looks like vanilla literals are missing from the assignment statement. That means 

```
My thing is 5
```

, which should work, gives the following error 

```
line 1:12 mismatched input '5' expecting {PRONOUNS, COMMON_VARIABLE_PREFIXES, CONSTANT_UNDEFINED, CONSTANT_NULL, CONSTANT_TRUE, CONSTANT_FALSE, KW_PUT, KW_INTO, KW_SAYS, KW_TAKING, KW_TAKES, KW_LISTEN, KW_TO, KW_SAY, KW_LOOP, KW_IF, KW_ELSE, KW_BUILD, KW_UP, KW_KNOCK, KW_DOWN, KW_GIVE, KW_BACK, KW_CONTINUE, KW_BREAK, KW_NOT, KW_MULTIPLY, KW_DIVIDE, KW_ADD, KW_SUBTRACT, KW_IS, KW_NOT_EQUAL, KW_WAS_WERE, KW_THAN, KW_AS, KW_GREATER, KW_LESS, KW_GREATER_EQUAL, KW_LESS_EQUAL, KW_AND, KW_OR, KW_NOR, WORD, NOUN}
```
